### PR TITLE
Improve readability of commands page examples

### DIFF
--- a/_docs/commands.md
+++ b/_docs/commands.md
@@ -7,24 +7,29 @@ order: 7
 
 ## Running commands on servers
 
-You can execute one-off commands on the servers:
+Execute a one-off command on all servers:
 
-```bash
-# Runs command on all servers
-mrsk app exec 'ruby -v'
+```console
+$ mrsk app exec 'ruby -v'
 App Host: 192.168.0.1
 ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
 
 App Host: 192.168.0.2
 ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
+```
 
-# Runs command on primary server
-mrsk app exec --primary 'cat .ruby-version'
+Execute a command on just the primary server:
+
+```console
+$ mrsk app exec --primary 'cat .ruby-version'
 App Host: 192.168.0.1
 3.1.3
+```
 
-# Runs Rails command on all servers
-mrsk app exec 'bin/rails about'
+Execute the `bin/rails` command on all servers:
+
+```console
+$ mrsk app exec 'bin/rails about'
 App Host: 192.168.0.1
 About your application's environment
 Rails version             7.1.0.alpha
@@ -48,9 +53,12 @@ Application root          /rails
 Environment               production
 Database adapter          sqlite3
 Database schema version   20221231233303
+```
 
-# Run Rails runner on primary server
-mrsk app exec -p 'bin/rails runner "puts Rails.application.config.time_zone"'
+Use the Rails runner on just the primary server:
+
+```console
+$ mrsk app exec -p 'bin/rails runner "puts Rails.application.config.time_zone"'
 UTC
 ```
 


### PR DESCRIPTION
Two changes here:

- Separate out each example command in the first section into its own code block, instead of one large code block.
- Use `console` instead of `bash` for syntax highlighting for the CLI examples, which gets a better highlighting result for the combination of commands and their output.

Before:

<img width="989" alt="Screenshot 2023-06-23 at 9 29 33 AM" src="https://github.com/mrsked/mrsk-site/assets/225/d3748b78-5953-4c6e-b453-4b5c82901fc7">

After:

<img width="982" alt="Screenshot 2023-06-23 at 9 29 38 AM" src="https://github.com/mrsked/mrsk-site/assets/225/b7275374-192b-40f6-81dc-51fe47a6b8c2">
